### PR TITLE
Forward the environment keys to PHP CS Fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~10.2",
-        "vimeo/psalm": "~5.15",
+        "innmind/static-analysis": "~1.1",
         "innmind/black-box": "~5.5",
         "innmind/coding-standard": "~2.0"
     },

--- a/src/Trigger/CodingStandard.php
+++ b/src/Trigger/CodingStandard.php
@@ -68,7 +68,11 @@ final class CodingStandard implements Trigger
         /** @var Map<non-empty-string, string> */
         $variables = $console
             ->variables()
-            ->filter(static fn($key) => $key === 'PATH');
+            ->filter(static fn($key) => \in_array(
+                $key,
+                ['PATH', 'PHP_CS_FIXER_IGNORE_ENV'],
+                true,
+            ));
 
         $command = Command::foreground('vendor/bin/php-cs-fixer')
             ->withArgument('fix')


### PR DESCRIPTION
This allows a user to defined a environment key is its shell and still be understood by PHP CS Fixer inside this tool.

Right now only `PHP_CS_FIXER_IGNORE_ENV` is forwarded.

This is necessary to explicitly specify the keys since by default `innmind/server-control` doesn't forward environment variables (to avoid implicits).

Fixes #2 