### PR TITLE
Run Psalm with the current php version as target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Psalm is now run with the current PHP version as the target one (instead of the minimal one defined in `composer.json`)
+
 ## 4.3.1 - 2026-02-28
 
 ### Fixed

--- a/src/Trigger/Psalm.php
+++ b/src/Trigger/Psalm.php
@@ -84,6 +84,11 @@ final class Psalm implements Trigger
             ->execute(
                 Command::foreground('vendor/bin/psalm')
                     ->withOption('no-cache')
+                    ->withOption(\sprintf(
+                        'php-version=%s.%s',
+                        \PHP_MAJOR_VERSION,
+                        \PHP_MINOR_VERSION,
+                    ))
                     ->withWorkingDirectory($console->workingDirectory())
                     ->withEnvironments($variables),
             )

--- a/tests/Trigger/PsalmTest.php
+++ b/tests/Trigger/PsalmTest.php
@@ -147,9 +147,11 @@ class PsalmTest extends TestCase
                 ->mountFilesystemVia(static fn() => Attempt::result($adapter))
                 ->useServerControl(Server::via(
                     function($command) use (&$count) {
+                        $major = \PHP_MAJOR_VERSION;
+                        $minor = \PHP_MINOR_VERSION;
                         $this->assertSame(
                             match ($count) {
-                                0 => "vendor/bin/psalm '--no-cache'",
+                                0 => "vendor/bin/psalm '--no-cache' '--php-version=$major.$minor'",
                                 1 => "say 'Psalm : ok'",
                             },
                             $command->toString(),
@@ -226,9 +228,11 @@ class PsalmTest extends TestCase
                 ->mountFilesystemVia(static fn() => Attempt::result($adapter))
                 ->useServerControl(Server::via(
                     function($command) use (&$count) {
+                        $major = \PHP_MAJOR_VERSION;
+                        $minor = \PHP_MINOR_VERSION;
                         $this->assertSame(
                             match ($count) {
-                                0 => "vendor/bin/psalm '--no-cache'",
+                                0 => "vendor/bin/psalm '--no-cache' '--php-version=$major.$minor'",
                                 1 => "say 'Psalm : ok'",
                             },
                             $command->toString(),
@@ -297,9 +301,11 @@ class PsalmTest extends TestCase
                 ->mountFilesystemVia(static fn() => Attempt::result($adapter))
                 ->useServerControl(Server::via(
                     function($command) use (&$count) {
+                        $major = \PHP_MAJOR_VERSION;
+                        $minor = \PHP_MINOR_VERSION;
                         $this->assertSame(
                             match ($count) {
-                                0 => "vendor/bin/psalm '--no-cache'",
+                                0 => "vendor/bin/psalm '--no-cache' '--php-version=$major.$minor'",
                                 1 => "say 'Psalm : failing'",
                             },
                             $command->toString(),
@@ -371,9 +377,11 @@ class PsalmTest extends TestCase
                 ->mountFilesystemVia(static fn() => Attempt::result($adapter))
                 ->useServerControl(Server::via(
                     function($command) use (&$count) {
+                        $major = \PHP_MAJOR_VERSION;
+                        $minor = \PHP_MINOR_VERSION;
                         $this->assertSame(
                             match ($count) {
-                                0 => "vendor/bin/psalm '--no-cache'",
+                                0 => "vendor/bin/psalm '--no-cache' '--php-version=$major.$minor'",
                             },
                             $command->toString(),
                         );


### PR DESCRIPTION
This is to avoid running on PHP 8.5 and targeting a minimal version of 8.4. This creates incompatibilities such as `NoDiscard` saying it is an invalid attribute, as it doesn't exist in PHP 8.4 (but it's not a problem as it will do nothing on PHP 8.4)